### PR TITLE
Feature: disable auto index creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,24 +349,7 @@ By default it is `{ nextRunAt: 1, priority: -1 }`, which obeys a first in first 
 Optional. Disables the automatic creation of the default index on the jobs table.
 By default, Agenda creates an index to optimize its queries against Mongo while processing jobs.
 
-This is useful if you want to use your own index in a specific use-case
-
-### index(object)
-
-Optional. Takes an object which specifies the index to create on the jobs collection.
-
-The default index is:
-```json
-{
-  name: 1,
-  nextRunAt: 1,
-  priority: -1,
-  lockedAt: 1,
-  disabled: 1
-}
-```
-
-It is recommended to use the default index. This optional configuration is meant to enable specific optimizations that might be required under specific use-cases.
+This is useful if you want to use your own index in specific use-cases.
 
 ## Agenda Events
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,13 @@ Takes a `query` which specifies the sort query to be used for finding and lockin
 
 By default it is `{ nextRunAt: 1, priority: -1 }`, which obeys a first in first out approach, with respect to priority.
 
+### disableAutoIndex(boolean)
+
+Optional. Disables the automatic creation of the default index on the jobs table.
+By default, Agenda creates an index to optimize its queries against Mongo while processing jobs.
+
+This is useful if you want to use your own index in a specific use-case
+
 ### index(object)
 
 Optional. Takes an object which specifies the index to create on the jobs collection.

--- a/lib/agenda/db-init.ts
+++ b/lib/agenda/db-init.ts
@@ -18,6 +18,12 @@ export const dbInit = function (
 ): void {
   debug("init database collection using name [%s]", collection);
   this._collection = this._mdb.collection(collection);
+  if (this._disableAutoIndex) {
+    debug("skipping auto index creation");
+    this.emit("ready");
+    return;
+  }
+
   debug("attempting index creation");
   this._collection.createIndex(
     this._indices,

--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -52,6 +52,7 @@ export interface AgendaConfig {
     options?: MongoClientOptions;
   };
   index?: any,
+  disableAutoIndex?: boolean;
 }
 
 /**
@@ -82,6 +83,7 @@ class Agenda extends EventEmitter {
   _definitions: any;
   _findAndLockNextJob = findAndLockNextJob;
   _indices: any;
+  _disableAutoIndex: boolean;
   _isLockingOnTheFly: boolean;
   _isJobQueueFilling: Map<string, boolean>;
   _jobQueue: JobProcessingQueue;
@@ -162,6 +164,7 @@ class Agenda extends EventEmitter {
       nextRunAt: 1,
       disabled: 1,
     };
+    this._disableAutoIndex = config.disableAutoIndex === true;
 
     this._isLockingOnTheFly = false;
     this._isJobQueueFilling = new Map<string, boolean>();

--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -51,7 +51,6 @@ export interface AgendaConfig {
     collection?: string;
     options?: MongoClientOptions;
   };
-  index?: any,
   disableAutoIndex?: boolean;
 }
 
@@ -156,7 +155,7 @@ class Agenda extends EventEmitter {
     this._jobQueue = new JobProcessingQueue();
     this._defaultLockLifetime = config.defaultLockLifetime || 10 * 60 * 1000; // 10 minute default lockLifetime
     this._sort = config.sort || { nextRunAt: 1, priority: -1 };
-    this._indices = config.index || {
+    this._indices = {
       name: 1,
       ...this._sort,
       priority: -1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenda",
-  "version": "4.3.1",
+  "version": "4.2.1",
   "description": "Light weight job scheduler for Node.js",
   "main": "dist/cjs.js",
   "types": "dist/index.d.ts",

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -220,165 +220,120 @@ describe("Agenda", () => {
           7777
         );
       });
+    });
 
-      describe('custom index', () => {
-        it('should create default index when custom index is not specified', async () => {
-          const collectionName = 'agenda_index_test';
+    describe('disable auto index', () => {
+      it('should create default index when disableAutoIndex is not specified', async () => {
+        const collectionName = 'agenda_index_test';
 
-          const agenda2 = new Agenda({
-            db: {
-              address: mongoCfg,
-              collection: collectionName,
-            },
-          });
-
-          await agenda2._ready;
-
-          const collection = agenda2._mdb.collection(collectionName);
-
-          try {
-            const indexes = await collection.indexes();
-
-            const expectedIndex = {
-              "key": {
-                "name": 1,
-                "nextRunAt": 1,
-                "priority": -1,
-                "lockedAt": 1,
-                "disabled": 1
-              },
-              "name": "findAndLockNextJobIndex",
-            };
-
-            const index = indexes.find(index => index.name === expectedIndex.name);
-
-            expect(index).to.not.be(null);
-            expect(index.key).to.eql(expectedIndex.key);
-
-          } finally {
-            await agenda2._mdb.dropCollection(collectionName);
-            await agenda2.stop();
-            await agenda2.close();
-          }
+        const agenda2 = new Agenda({
+          db: {
+            address: mongoCfg,
+            collection: collectionName,
+          },
         });
 
-        it('should create custom index when it is specified', async () => {
-          const collectionName = 'agenda_index_test';
+        await agenda2._ready;
 
-          const agenda2 = new Agenda({
-            db: {
-              address: mongoCfg,
-              collection: collectionName,
-            },
-            index: {
-              name: 1,
-              disabled: 1,
-              nextRunAt: 1,
-            }
-          });
+        const collection = agenda2._mdb.collection(collectionName);
 
-          await agenda2._ready;
+        try {
+          const indexes = await collection.indexes();
 
-          const collection = agenda2._mdb.collection(collectionName);
-
-          try {
-            const indexes = await collection.indexes();
-
-            const expectedIndex = {
-              "key": {
-                "name": 1,
-                "disabled": 1,
-                "nextRunAt": 1,
-              },
-              "name": "findAndLockNextJobIndex",
-            };
-
-            const index = indexes.find(index => index.name === expectedIndex.name);
-
-            expect(index).to.not.be(null);
-            expect(index.key).to.eql(expectedIndex.key);
-
-          } finally {
-            await agenda2._mdb.dropCollection(collectionName);
-            await agenda2.stop();
-            await agenda2.close();
-          }
-        });
-      });
-
-      describe('disable auto index', () => {
-        it('should not create index when auto index is disabled', async () => {
-          const collectionName = 'agenda_index_test';
-
-          const agenda2 = new Agenda({
-            db: {
-              address: mongoCfg,
-              collection: collectionName,
-            },
-            disableAutoIndex: true,
-          });
-
-          await agenda2._ready;
-
-          const collection = agenda2._collection;
-
-          try {
-            // We need an operation on the collection to trigger its creation before we can access the indexes method.
-            // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
-            await collection.insertOne({ name: 'test-job' });
-
-            const indexes = await collection.indexes();
-
-            const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
-
-            expect(index).to.be(undefined);
-            expect(indexes.length).to.be(1);
-          } finally {
-            await agenda2._mdb.dropCollection(collectionName);
-            await agenda2.stop();
-            await agenda2.close();
-          }
-        });
-
-        it('should create an index when auto index is enabled', async () => {
-          const collectionName = 'agenda_index_test';
-
-          const agenda2 = new Agenda({
-            db: {
-              address: mongoCfg,
-              collection: collectionName,
-            },
-            disableAutoIndex: false,
-          });
-
-          await agenda2._ready;
-
-          const collection = agenda2._collection;
-
-          try {
-            // We need an operation on the collection to trigger its creation before we can access the indexes method.
-            // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
-            await collection.insertOne({ name: 'test-job' });
-
-            const indexes = await collection.indexes();
-
-            const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
-
-            const expectedIndex = {
+          const expectedIndex = {
+            "key": {
               "name": 1,
               "nextRunAt": 1,
               "priority": -1,
               "lockedAt": 1,
               "disabled": 1
-            };
+            },
+            "name": "findAndLockNextJobIndex",
+          };
 
-            expect(index.key).to.eql(expectedIndex);
-          } finally {
-            await agenda2._mdb.dropCollection(collectionName);
-            await agenda2.stop();
-            await agenda2.close();
-          }
+          const index = indexes.find(index => index.name === expectedIndex.name);
+
+          expect(index).to.not.be(null);
+          expect(index.key).to.eql(expectedIndex.key);
+
+        } finally {
+          await agenda2._mdb.dropCollection(collectionName);
+          await agenda2.stop();
+          await agenda2.close();
+        }
+      });
+
+      it('should not create index when auto index is disabled', async () => {
+        const collectionName = 'agenda_index_test';
+
+        const agenda2 = new Agenda({
+          db: {
+            address: mongoCfg,
+            collection: collectionName,
+          },
+          disableAutoIndex: true,
         });
+
+        await agenda2._ready;
+
+        const collection = agenda2._collection;
+
+        try {
+          // We need an operation on the collection to trigger its creation before we can access the indexes method.
+          // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
+          await collection.insertOne({ name: 'test-job' });
+
+          const indexes = await collection.indexes();
+
+          const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
+
+          expect(index).to.be(undefined);
+          expect(indexes.length).to.be(1);
+        } finally {
+          await agenda2._mdb.dropCollection(collectionName);
+          await agenda2.stop();
+          await agenda2.close();
+        }
+      });
+
+      it('should create an index when auto index is enabled', async () => {
+        const collectionName = 'agenda_index_test';
+
+        const agenda2 = new Agenda({
+          db: {
+            address: mongoCfg,
+            collection: collectionName,
+          },
+          disableAutoIndex: false,
+        });
+
+        await agenda2._ready;
+
+        const collection = agenda2._collection;
+
+        try {
+          // We need an operation on the collection to trigger its creation before we can access the indexes method.
+          // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
+          await collection.insertOne({ name: 'test-job' });
+
+          const indexes = await collection.indexes();
+
+          const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
+
+          const expectedIndex = {
+            "name": 1,
+            "nextRunAt": 1,
+            "priority": -1,
+            "lockedAt": 1,
+            "disabled": 1
+          };
+
+          expect(index.key).to.eql(expectedIndex);
+        } finally {
+          await agenda2._mdb.dropCollection(collectionName);
+          await agenda2.stop();
+          await agenda2.close();
+        }
       });
     });
 

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -305,6 +305,37 @@ describe("Agenda", () => {
           }
         });
       });
+
+      describe('disable auto index', () => {
+        it('should not create index when auto index is disabled', async () => {
+          const collectionName = 'agenda_index_test';
+
+          const agenda2 = new Agenda({
+            db: {
+              address: mongoCfg,
+              collection: collectionName,
+            },
+            disableAutoIndex: true,
+          });
+
+          await agenda2._ready;
+
+          const collection = agenda2._mdb.collection(collectionName);
+
+          try {
+            const indexes = await collection.indexes();
+
+            const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
+
+            expect(index).to.be(null);
+            expect(indexes.length).to.be(1);
+          } finally {
+            await agenda2._mdb.dropCollection(collectionName);
+            await agenda2.stop();
+            await agenda2.close();
+          }
+        });
+      });
     });
     describe("sort", () => {
       it("returns itself", () => {

--- a/test/agenda.js
+++ b/test/agenda.js
@@ -320,15 +320,59 @@ describe("Agenda", () => {
 
           await agenda2._ready;
 
-          const collection = agenda2._mdb.collection(collectionName);
+          const collection = agenda2._collection;
 
           try {
+            // We need an operation on the collection to trigger its creation before we can access the indexes method.
+            // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
+            await collection.insertOne({ name: 'test-job' });
+
             const indexes = await collection.indexes();
 
             const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
 
-            expect(index).to.be(null);
+            expect(index).to.be(undefined);
             expect(indexes.length).to.be(1);
+          } finally {
+            await agenda2._mdb.dropCollection(collectionName);
+            await agenda2.stop();
+            await agenda2.close();
+          }
+        });
+
+        it('should create an index when auto index is enabled', async () => {
+          const collectionName = 'agenda_index_test';
+
+          const agenda2 = new Agenda({
+            db: {
+              address: mongoCfg,
+              collection: collectionName,
+            },
+            disableAutoIndex: false,
+          });
+
+          await agenda2._ready;
+
+          const collection = agenda2._collection;
+
+          try {
+            // We need an operation on the collection to trigger its creation before we can access the indexes method.
+            // Current implementation of mmongodb driver throws an error as it query the indexes from the namespace which is de-coupled from the collection object itself.
+            await collection.insertOne({ name: 'test-job' });
+
+            const indexes = await collection.indexes();
+
+            const index = indexes.find(index => index.name === "findAndLockNextJobIndex");
+
+            const expectedIndex = {
+              "name": 1,
+              "nextRunAt": 1,
+              "priority": -1,
+              "lockedAt": 1,
+              "disabled": 1
+            };
+
+            expect(index.key).to.eql(expectedIndex);
           } finally {
             await agenda2._mdb.dropCollection(collectionName);
             await agenda2.stop();
@@ -337,6 +381,7 @@ describe("Agenda", () => {
         });
       });
     });
+
     describe("sort", () => {
       it("returns itself", () => {
         expect(agenda.sort({ nextRunAt: 1, priority: -1 })).to.be(agenda);


### PR DESCRIPTION
Per discussions with the Agenda contributors, they recommended to add a configuration to disable the auto index creation instead of customizing the index.
It is actually better for us, since it makes the deployment to prod with zero risk (as opposed to the custom index which requires a short downtime)